### PR TITLE
add Coal add remove and change visibility of classes for plasmids

### DIFF
--- a/src/coalre/distribution/CoalescentWithReassortment.java
+++ b/src/coalre/distribution/CoalescentWithReassortment.java
@@ -26,9 +26,9 @@ public class CoalescentWithReassortment extends NetworkDistribution {
             "Population model.",
             Input.Validate.REQUIRED);
 
-    private PopulationFunction populationFunction;
+    public PopulationFunction populationFunction;
     private Function reassortmentRate;
-    private NetworkIntervals intervals;
+    public NetworkIntervals intervals;
 
     @Override
     public void initAndValidate(){

--- a/src/coalre/distribution/NetworkEvent.java
+++ b/src/coalre/distribution/NetworkEvent.java
@@ -13,12 +13,12 @@ public class NetworkEvent {
     /**
      * Number of segments on a reassorting lineage.
      */
-    int segsToSort;
+    public int segsToSort;
 
     /**
      * Number of segments sent to the first parent.
      */
-    int segsSortedLeft;
+    public int segsSortedLeft;
 
     public int lineages;
     public double totalReassortmentObsProb;

--- a/src/coalre/distribution/NetworkEvent.java
+++ b/src/coalre/distribution/NetworkEvent.java
@@ -28,4 +28,10 @@ public class NetworkEvent {
      * May not point to a compatible node at other times.
      */
     public NetworkNode node;
+    
+    @Override
+    public String toString() {
+		return type +":"+ lineages +":" +totalReassortmentObsProb;
+    	
+    }
 }

--- a/src/coalre/distribution/NetworkEvent.java
+++ b/src/coalre/distribution/NetworkEvent.java
@@ -14,6 +14,18 @@ public class NetworkEvent {
      * Number of segments on a reassorting lineage.
      */
     public int segsToSort;
+    
+    /**
+     * Which segments went left, needed for plasmids.
+     */
+    public BitSet segsLeft;
+    
+    /**
+     * whcih segments went right, needed for plasmids.
+     */
+    public BitSet segsRight;
+
+
 
     /**
      * Number of segments sent to the first parent.

--- a/src/coalre/distribution/NetworkIntervals.java
+++ b/src/coalre/distribution/NetworkIntervals.java
@@ -37,7 +37,7 @@ public class NetworkIntervals extends CalculationNode {
         storedNetworkEventList = new ArrayList<>();
     }
 
-    List<NetworkEvent> getNetworkEventList() {
+    public List<NetworkEvent> getNetworkEventList() {
         update();
 
         return networkEventList;

--- a/src/coalre/network/Network.java
+++ b/src/coalre/network/Network.java
@@ -22,7 +22,7 @@ public class Network extends StateNode {
 
     protected NetworkEdge storedRootEdge;
 
-    protected Integer segmentCount = null;
+    public Integer segmentCount = null;
     
     public Network() {
     }
@@ -628,7 +628,7 @@ public class Network extends StateNode {
         if (nodeNrArrays.keySet().contains(segmentTree))
             return nodeNrArrays.get(segmentTree);
 
-        int[] nodeNumberMap = new int[getLeafNodes().size()];
+        int[] nodeNumberMap = new int[segmentTree.getLeafNodeCount()];
 
         for (int treeNodeNr=0; treeNodeNr<nodeNumberMap.length; treeNodeNr++) {
             Node treeNode = segmentTree.getNode(treeNodeNr);

--- a/src/coalre/network/Network.java
+++ b/src/coalre/network/Network.java
@@ -113,8 +113,14 @@ public class Network extends StateNode {
      * @return number of segments represented on network
      */
     public int getSegmentCount() {
-        if (segmentCount == null)
-            segmentCount = getLeafNodes().iterator().next().getParentEdges().get(0).hasSegments.cardinality();
+        if (segmentCount == null) {
+        	// allow for different number of segments on different leaves
+        	BitSet totsegment = new BitSet();
+        	for (NetworkNode n : getLeafNodes()) {
+        		totsegment.or(n.getParentEdges().get(0).hasSegments);
+        	}   
+            segmentCount = totsegment.cardinality();
+        }
 
         return segmentCount;
     }

--- a/src/coalre/network/SegmentTreeInitializer.java
+++ b/src/coalre/network/SegmentTreeInitializer.java
@@ -41,11 +41,11 @@ public class SegmentTreeInitializer extends BEASTObject implements StateNodeInit
             if (segmentIndex >= nSegments)
                 throw new IllegalArgumentException("Illegal segment index given.");
         }
+
     }
 
     @Override
     public void initStateNodes() {
-
         if (segmentIndex != null) {
             network.updateSegmentTree(segmentTrees.get(0), segmentIndexInput.get());
         } else {
@@ -53,7 +53,6 @@ public class SegmentTreeInitializer extends BEASTObject implements StateNodeInit
                 network.updateSegmentTree(segmentTrees.get(segIdx), segIdx);
             }
         }
-
     }
 
     @Override

--- a/src/coalre/networkannotator/ReassortmentAnnotator.java
+++ b/src/coalre/networkannotator/ReassortmentAnnotator.java
@@ -36,21 +36,28 @@ public class ReassortmentAnnotator {
 	 * @param network
 	 * @param segmentToRemove
 	 */
-	protected void pruneNetwork(Network network, int[] segmentToRemove){
+	void pruneNetwork(Network network, int[] segmentToRemove){
     	// remove all parts of the network that aren't informed by the genetic data
     	removeNonGeneticSegmentEdges(network);
     	for (int i = 0; i < segmentToRemove.length; i++)
     		removeSegment(network, segmentToRemove[i]);
+    	
+    	
+    	System.out.println(network);
 
     	// remove all loops
     	removeLoops(network);
+    	System.out.println(network);
+
     	// remove all empty edges in the segment
     	removeEmptyNetworkEdge(network);      
     	// remove all loops
     	removeLoops(network);
 
+
     	// remove all empty edges in the segment
     	removeEmptyNetworkEdge(network);  
+
 	}
 	
     /**
@@ -114,23 +121,41 @@ public class ReassortmentAnnotator {
                 .filter(e -> e.getParentEdges().get(1).hasSegments.cardinality()>0)
                 .collect(Collectors.toList());
     	
+    	int counter = 0;
+    	
     	// for each of these, check if the parents are the same node
     	while (!reticulationNodes.isEmpty()){
     		NetworkNode node = reticulationNodes.get(0);
-			// if this is the case, put all segment from 1 onto 0
+			// if this is the case, put all segments from 1 onto 0
 			for (int i = 0; i < network.getSegmentCount(); i++){
-				if (node.getParentEdges().get(1).hasSegments.get(i)){
+				if (node.getChildEdges().get(0).hasSegments.get(i)){
+					System.out.println("moved " + i);
 					node.getParentEdges().get(0).hasSegments.set(i, true);
 					node.getParentEdges().get(1).hasSegments.set(i, false);
-				}    					
+				}    		
 			}
+			System.out.println(network.getSegmentCount());
+			System.out.println(node.getHeight());
+			System.out.println(node.getChildEdges().get(0).hasSegments);
+			System.out.println(node.getParentEdges().get(0).hasSegments);
+			System.out.println(node.getParentEdges().get(1).hasSegments);
+			
+//			System.out.println(network);
 			
 			removeEmptyNetworkEdge(network);
 			reticulationNodes = network.getNodes().stream()
 	                .filter(e -> e.isReassortment())
 	                .filter(e -> e.getParentEdges().get(0).parentNode.equals(e.getParentEdges().get(1).parentNode))
 	                .filter(e -> e.getParentEdges().get(1).hasSegments.cardinality()>0)
-	                .collect(Collectors.toList());			
+	                .collect(Collectors.toList());		
+			counter++;
+			
+			if (counter>10) {
+				System.err.println(network);
+	    		throw new IllegalArgumentException("tried to remove " + counter + " loops, but still not done " + reticulationNodes.size() + " loops left");
+
+			}
+			
     	}
     }
 

--- a/src/coalre/networkannotator/ReassortmentAnnotator.java
+++ b/src/coalre/networkannotator/ReassortmentAnnotator.java
@@ -36,7 +36,7 @@ public class ReassortmentAnnotator {
 	 * @param network
 	 * @param segmentToRemove
 	 */
-	void pruneNetwork(Network network, int[] segmentToRemove){
+	protected void pruneNetwork(Network network, int[] segmentToRemove){
     	// remove all parts of the network that aren't informed by the genetic data
     	removeNonGeneticSegmentEdges(network);
     	for (int i = 0; i < segmentToRemove.length; i++)

--- a/src/coalre/networkannotator/ReassortmentAnnotator.java
+++ b/src/coalre/networkannotator/ReassortmentAnnotator.java
@@ -41,23 +41,16 @@ public class ReassortmentAnnotator {
     	removeNonGeneticSegmentEdges(network);
     	for (int i = 0; i < segmentToRemove.length; i++)
     		removeSegment(network, segmentToRemove[i]);
-    	
-    	
-    	System.out.println(network);
 
     	// remove all loops
     	removeLoops(network);
-    	System.out.println(network);
-
     	// remove all empty edges in the segment
     	removeEmptyNetworkEdge(network);      
     	// remove all loops
     	removeLoops(network);
 
-
     	// remove all empty edges in the segment
     	removeEmptyNetworkEdge(network);  
-
 	}
 	
     /**
@@ -121,41 +114,23 @@ public class ReassortmentAnnotator {
                 .filter(e -> e.getParentEdges().get(1).hasSegments.cardinality()>0)
                 .collect(Collectors.toList());
     	
-    	int counter = 0;
-    	
     	// for each of these, check if the parents are the same node
     	while (!reticulationNodes.isEmpty()){
     		NetworkNode node = reticulationNodes.get(0);
-			// if this is the case, put all segments from 1 onto 0
+			// if this is the case, put all segment from 1 onto 0
 			for (int i = 0; i < network.getSegmentCount(); i++){
-				if (node.getChildEdges().get(0).hasSegments.get(i)){
-					System.out.println("moved " + i);
+				if (node.getParentEdges().get(1).hasSegments.get(i)){
 					node.getParentEdges().get(0).hasSegments.set(i, true);
 					node.getParentEdges().get(1).hasSegments.set(i, false);
-				}    		
+				}    					
 			}
-			System.out.println(network.getSegmentCount());
-			System.out.println(node.getHeight());
-			System.out.println(node.getChildEdges().get(0).hasSegments);
-			System.out.println(node.getParentEdges().get(0).hasSegments);
-			System.out.println(node.getParentEdges().get(1).hasSegments);
-			
-//			System.out.println(network);
 			
 			removeEmptyNetworkEdge(network);
 			reticulationNodes = network.getNodes().stream()
 	                .filter(e -> e.isReassortment())
 	                .filter(e -> e.getParentEdges().get(0).parentNode.equals(e.getParentEdges().get(1).parentNode))
 	                .filter(e -> e.getParentEdges().get(1).hasSegments.cardinality()>0)
-	                .collect(Collectors.toList());		
-			counter++;
-			
-			if (counter>10) {
-				System.err.println(network);
-	    		throw new IllegalArgumentException("tried to remove " + counter + " loops, but still not done " + reticulationNodes.size() + " loops left");
-
-			}
-			
+	                .collect(Collectors.toList());			
     	}
     }
 

--- a/src/coalre/networkannotator/ReassortmentNetworkSummarizer.java
+++ b/src/coalre/networkannotator/ReassortmentNetworkSummarizer.java
@@ -38,7 +38,7 @@ import java.util.List;
  */
 public class ReassortmentNetworkSummarizer extends ReassortmentAnnotator {
 
-    private enum SummaryStrategy { MEAN, MEDIAN }
+    private enum SummaryStrategy { MEAN, MEDIAN, MCC_node_height }
 
     private static class NetworkAnnotatorOptions {
         File inFile;
@@ -171,9 +171,11 @@ public class ReassortmentNetworkSummarizer extends ReassortmentAnnotator {
         // print the network to file
         System.out.println("\nSummarize Atributes...");        
     	if (options.summaryStrategy == SummaryStrategy.MEAN)
-    		bestCladeSystem.summarizeAttributes(bestNetwork, attributeNames, true, logReader.getCorrectedNetworkCount(), onTarget);
+    		bestCladeSystem.summarizeAttributes(bestNetwork, attributeNames, 1, logReader.getCorrectedNetworkCount(), onTarget);
+    	else if (options.summaryStrategy == SummaryStrategy.MEDIAN)
+    		bestCladeSystem.summarizeAttributes(bestNetwork, attributeNames, 2, logReader.getCorrectedNetworkCount(), onTarget);
     	else
-    		bestCladeSystem.summarizeAttributes(bestNetwork, attributeNames, false, logReader.getCorrectedNetworkCount(), onTarget);
+    		bestCladeSystem.summarizeAttributes(bestNetwork, attributeNames, 3, logReader.getCorrectedNetworkCount(), onTarget);
 
     	// print the network to file
         System.out.println("\nWriting output to " + options.outFile.getName()
@@ -443,9 +445,9 @@ public class ReassortmentNetworkSummarizer extends ReassortmentAnnotator {
     }
 
     public static String helpMessage =
-            "ACGAnnotator - produces summaries of Bacter ACG log files.\n"
+            "ACGAnnotator - produces summaries of Reassortment Network log files.\n"
                     + "\n"
-                    + "Usage: appstore ACGAnnotator [-help | [options] logFile [outputFile]\n"
+                    + "Usage: appstore ReassortmentNetworkSummarizer [-help | [options] logFile [outputFile]\n"
                     + "\n"
                     + "Option                   Description\n"
                     + "--------------------------------------------------------------\n"
@@ -530,8 +532,23 @@ public class ReassortmentNetworkSummarizer extends ReassortmentAnnotator {
                         i += 1;
                         break;
                     }
+                    
+                    if (args[i+1].toLowerCase().equals("none")) {
+                        options.summaryStrategy = SummaryStrategy.MCC_node_height;
 
-                    printUsageAndError("-positions must be followed by either 'MEAN' or 'MEDIAN'.");
+                        i += 1;
+                        break;
+                    }
+                    
+                    if (args[i+1].toLowerCase().equals("mcc")) {
+                        options.summaryStrategy = SummaryStrategy.MCC_node_height;
+
+                        i += 1;
+                        break;
+                    }
+
+
+                    printUsageAndError("-positions must be followed by either 'MEAN' or 'MEDIAN' or 'MCC'.");
 
                 case "-removeSegments":
                     if (args.length<=i+1) {

--- a/src/coalre/operators/AddRemoveReassortmentCoalescent.java
+++ b/src/coalre/operators/AddRemoveReassortmentCoalescent.java
@@ -1,0 +1,361 @@
+package coalre.operators;
+
+import beast.core.Input;
+import beast.util.Randomizer;
+import coalre.distribution.CoalescentWithReassortment;
+import coalre.distribution.NetworkEvent;
+import coalre.network.NetworkEdge;
+import coalre.network.NetworkNode;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class AddRemoveReassortmentCoalescent extends DivertSegmentOperator {
+
+    public Input<CoalescentWithReassortment> coalescentDistrInput = new Input<>("coalescentWithReassortment",
+            "Mean of exponential used for choosing root attachment times.",
+            Input.Validate.REQUIRED);
+
+
+    CoalescentWithReassortment coalescentDistr;
+
+    @Override
+    public void initAndValidate() {
+        super.initAndValidate();
+        coalescentDistr = coalescentDistrInput.get();
+    }
+
+    @Override
+    public double networkProposal() {
+        double logHR;
+        if (Randomizer.nextBoolean()) {
+            logHR = addRecombination();
+        }else {
+            logHR = removeRecombination();
+        }
+        return logHR;
+    }
+
+    double addRecombination() {
+        double logHR = 0.0;
+//        System.out.println(network);
+
+        List<NetworkEdge> networkEdges = new ArrayList<>(network.getEdges());
+
+        List<NetworkEdge> possibleSourceEdges = networkEdges.stream()
+                .filter(e -> !e.isRootEdge())
+                .filter(e -> e.hasSegments.cardinality()>=2)
+                .collect(Collectors.toList());
+        
+        NetworkEdge sourceEdge = possibleSourceEdges.get(Randomizer.nextInt(possibleSourceEdges.size()));
+        double sourceTime = Randomizer.nextDouble() * sourceEdge.getLength() + sourceEdge.childNode.getHeight();
+
+        logHR -= Math.log(1.0/(double)possibleSourceEdges.size())
+                + Math.log(1.0/sourceEdge.getLength());
+        
+        coalescentDistr.intervals.eventListDirty = true;
+        
+    	// Calculate tree intervals
+    	List<NetworkEvent> networkEventList = coalescentDistr.intervals.getNetworkEventList();
+
+    	double currTime = sourceTime;
+    	NetworkEvent prevEvent = null;
+    	double attachmentTime = 0.0;
+    	
+    	for (NetworkEvent event : networkEventList) {
+    		if (event.time>currTime) {
+//    			System.out.println(currTime);
+    			// sample next possible attachment time
+    			double rate = 0.5*prevEvent.lineages;
+                double currentTransformedTime = coalescentDistr.populationFunction.getIntensity(currTime);
+                double transformedTimeToNextCoal = Randomizer.nextExponential(rate);
+                double timeToNextCoal = coalescentDistr.populationFunction.getInverseIntensity(
+                        transformedTimeToNextCoal + currentTransformedTime);
+                
+//                System.out.println(currTime + " " + timeToNextCoal + " " + currentTransformedTime);
+//                System.exit(0);
+
+
+                
+//                System.out.println(coalescentDistr.populationFunction.getPopSize(attachmentTime));
+               	attachmentTime = timeToNextCoal;
+                if (timeToNextCoal < event.time) {
+                	logHR -= -rate * coalescentDistr.populationFunction.getIntegral(currTime, attachmentTime) +
+                			Math.log(rate/coalescentDistr.populationFunction.getPopSize(attachmentTime));
+                	break;
+                }
+                logHR -= -rate * coalescentDistr.populationFunction.getIntegral(currTime, event.time);
+    			currTime = event.time;
+    		}
+    		prevEvent = event;
+        }    	
+    	
+    	if (attachmentTime>network.getRootEdge().childNode.getHeight()) {    		
+            double currentTransformedTime = coalescentDistr.populationFunction.getIntensity(network.getRootEdge().childNode.getHeight());
+    		double transformedTimeToNextCoal = Randomizer.nextExponential(0.5);
+            attachmentTime = coalescentDistr.populationFunction.getInverseIntensity(
+                    transformedTimeToNextCoal + currentTransformedTime);
+            
+            
+//            System.out.println(currTime + " x " + attachmentTime + " " + currentTransformedTime);
+//            System.exit(0);
+
+            
+            logHR -= -0.5 * coalescentDistr.populationFunction.getIntegral(network.getRootEdge().childNode.getHeight(), attachmentTime);
+        	logHR -= Math.log(0.5/coalescentDistr.populationFunction.getPopSize(attachmentTime));
+
+    	}    	
+
+    	double destTime = attachmentTime;
+        // keep only those that coexist at the time of maxHeight
+        List<NetworkEdge> destEdges = networkEdges.stream()
+                .filter(e -> !e.isRootEdge())
+                .filter(e -> e.parentNode.getHeight()>destTime)
+                .filter(e -> e.childNode.getHeight()<=destTime)
+               .collect(Collectors.toList());
+        
+        if (destEdges.size()==0)
+        	destEdges.add(network.getRootEdge());
+        
+        
+        NetworkEdge destEdge = destEdges.get(Randomizer.nextInt(destEdges.size()));
+        logHR -= Math.log(1.0/destEdges.size());
+
+        if (!destEdge.isRootEdge() && destEdge.parentNode.getHeight() < sourceTime)
+            return Double.NEGATIVE_INFINITY;
+      
+
+        // Create new reassortment edge
+        logHR += addReassortmentEdge(sourceEdge, sourceTime, destEdge, destTime);
+       
+        if (logHR == Double.NEGATIVE_INFINITY)
+            return Double.NEGATIVE_INFINITY;        
+
+        // HR contribution for reverse move
+        int nRemovableEdges = (int) network.getEdges().stream()
+                .filter(e -> !e.isRootEdge())
+                .filter(e -> e.hasSegments.cardinality()>=1)
+                .filter(e -> e.childNode.isReassortment())
+                .filter(e -> e.parentNode.isCoalescence())
+                .count();
+        
+        logHR += Math.log(1.0/nRemovableEdges);
+//        System.out.println(network);
+//        System.exit(0);
+        return logHR;
+    }
+    
+    double addReassortmentEdge(NetworkEdge sourceEdge, double sourceTime,
+                               NetworkEdge destEdge, double destTime) {
+
+        double logHR = 0.0;
+
+        network.startEditing(this);
+
+        NetworkNode sourceNode = new NetworkNode();
+        sourceNode.setHeight(sourceTime);
+
+        NetworkNode oldSourceEdgeParent = sourceEdge.parentNode;
+        oldSourceEdgeParent.removeChildEdge(sourceEdge);
+        sourceNode.addChildEdge(sourceEdge);
+
+        NetworkEdge newEdge1 = new NetworkEdge();
+        sourceNode.addParentEdge(newEdge1);
+        oldSourceEdgeParent.addChildEdge(newEdge1);
+
+        newEdge1.hasSegments = (BitSet) sourceEdge.hasSegments.clone();
+
+        if (destEdge == sourceEdge)
+            destEdge = newEdge1;
+
+        NetworkNode destNode = new NetworkNode();
+        destNode.setHeight(destTime);
+
+        NetworkNode oldDestEdgeParent = destEdge.parentNode;
+        if (oldDestEdgeParent != null) {
+            oldDestEdgeParent.removeChildEdge(destEdge);
+        }
+
+        destNode.addChildEdge(destEdge);
+
+        NetworkEdge newEdge2 = new NetworkEdge();
+        destNode.addParentEdge(newEdge2);
+
+        if (oldDestEdgeParent == null) {
+            network.setRootEdge(newEdge2);
+        } else {
+            oldDestEdgeParent.addChildEdge(newEdge2);
+        }
+
+        newEdge2.hasSegments = (BitSet) destEdge.hasSegments.clone();
+
+        NetworkEdge reassortmentEdge = new NetworkEdge();
+        sourceNode.addParentEdge(reassortmentEdge);
+        destNode.addChildEdge(reassortmentEdge);
+        reassortmentEdge.hasSegments = new BitSet();
+
+        // Choose segments to divert to new edge
+        BitSet segsToDivert = getRandomConditionedSubset(sourceEdge.hasSegments);
+        logHR -= getLogConditionedSubsetProb(sourceEdge.hasSegments);
+        logHR -= addSegmentsToAncestors(reassortmentEdge, segsToDivert);
+        logHR += removeSegmentsFromAncestors(newEdge1, segsToDivert);
+
+        return logHR;
+    }
+
+    double removeRecombination() {
+        double logHR = 0.0;
+        
+        List<NetworkEdge> removableEdges = network.getEdges().stream()
+                .filter(e -> !e.isRootEdge())
+                .filter(e -> e.hasSegments.cardinality()>=1)
+                .filter(e -> e.childNode.isReassortment())
+                .filter(e -> e.parentNode.isCoalescence())
+                .collect(Collectors.toList());
+        
+        
+        if (removableEdges.isEmpty())
+            return Double.NEGATIVE_INFINITY;
+
+        NetworkEdge edgeToRemove = removableEdges.get(Randomizer.nextInt(removableEdges.size()));
+        logHR -= Math.log(1.0/(removableEdges.size()));
+        
+
+        double sourceTime = edgeToRemove.childNode.getHeight();
+        NetworkEdge sourceEdge = edgeToRemove.childNode.getChildEdges().get(0);
+        NetworkEdge destEdge = getSisterEdge(edgeToRemove);
+        if (destEdge.childNode == edgeToRemove.childNode)
+            destEdge = sourceEdge;
+        double destTime = edgeToRemove.parentNode.getHeight();
+        
+        
+        coalescentDistr.intervals.eventListDirty = true;
+        
+    	// Calculate tree intervals
+    	List<NetworkEvent> networkEventList = coalescentDistr.intervals.getNetworkEventList();
+
+    	double currTime = sourceTime;
+    	NetworkEvent prevEvent = null;
+    	
+    	for (NetworkEvent event : networkEventList) {
+    		if (event.time>currTime) {                
+            	double rate = 0.5 * (prevEvent.lineages-1);
+                if (destTime<=event.time) {
+                	logHR += -rate* coalescentDistr.populationFunction.getIntegral(currTime, destTime);                	
+                	logHR += Math.log(rate/coalescentDistr.populationFunction.getPopSize(destTime));
+                	break;
+                }
+                logHR += -rate * coalescentDistr.populationFunction.getIntegral(currTime, event.time);
+    			currTime = event.time;
+    		}
+    		prevEvent = event;
+        }    	
+    	
+        // Remove reassortment edge
+        logHR += removeReassortmentEdge(edgeToRemove);
+        
+        if (logHR == Double.NEGATIVE_INFINITY)
+            return Double.NEGATIVE_INFINITY;
+
+        // HR contribution for reverse move
+
+        Set<NetworkEdge> finalNetworkEdges = network.getEdges();
+
+        int nPossibleSourceEdges = (int)finalNetworkEdges.stream()
+                .filter(e -> !e.isRootEdge())
+                .filter(e -> e.hasSegments.cardinality()>=2)
+                .count();
+
+        logHR += Math.log(1.0/(double)nPossibleSourceEdges)
+                + Math.log(1.0/sourceEdge.getLength());
+ 
+        // keep only those that coexist at the time of maxHeight
+        List<NetworkEdge> destEdges = finalNetworkEdges.stream()
+                .filter(e -> !e.isRootEdge())
+                .filter(e -> e.parentNode.getHeight()>destTime)
+                .filter(e -> e.childNode.getHeight()<=destTime)
+               .collect(Collectors.toList());
+        
+        if (destEdges.size()==0)
+        	destEdges.add(network.getRootEdge());
+        
+        logHR += Math.log(1.0/destEdges.size());
+
+
+
+        return logHR;
+    }
+
+
+    double removeReassortmentEdge(NetworkEdge edgeToRemove) {
+        double logHR = 0.0;
+
+        network.startEditing(this);
+
+        NetworkNode nodeToRemove = edgeToRemove.childNode;
+        NetworkEdge edgeToRemoveSpouse = getSpouseEdge(edgeToRemove);
+        NetworkNode edgeToRemoveSpouseParent = edgeToRemoveSpouse.parentNode;
+
+        // Divert segments away from chosen edge
+        BitSet segsToDivert = (BitSet) edgeToRemove.hasSegments.clone();
+        logHR -= addSegmentsToAncestors(edgeToRemoveSpouse, segsToDivert);
+        logHR += removeSegmentsFromAncestors(edgeToRemove, segsToDivert);
+        logHR += getLogConditionedSubsetProb(edgeToRemoveSpouse.hasSegments);
+
+        // Remove edge and associated nodes
+        NetworkEdge edgeToExtend = nodeToRemove.getChildEdges().get(0);
+        nodeToRemove.removeChildEdge(edgeToExtend);
+        nodeToRemove.removeParentEdge(edgeToRemove);
+        nodeToRemove.removeParentEdge(edgeToRemoveSpouse);
+        edgeToRemoveSpouseParent.removeChildEdge(edgeToRemoveSpouse);
+        edgeToRemoveSpouseParent.addChildEdge(edgeToExtend);
+
+        NetworkNode secondNodeToRemove = edgeToRemove.parentNode;
+        NetworkEdge secondEdgeToExtend = getSisterEdge(edgeToRemove);
+
+        secondNodeToRemove.removeChildEdge(secondEdgeToExtend);
+        secondNodeToRemove.removeChildEdge(edgeToRemove);
+
+        if (secondNodeToRemove.getParentEdges().get(0).isRootEdge()) {
+            network.setRootEdge(secondEdgeToExtend);
+
+        } else {
+            NetworkEdge secondNodeToRemoveParentEdge = secondNodeToRemove.getParentEdges().get(0);
+            NetworkNode secondNodeToRemoveParent = secondNodeToRemoveParentEdge.parentNode;
+            secondNodeToRemoveParent.removeChildEdge(secondNodeToRemoveParentEdge);
+            secondNodeToRemove.removeParentEdge(secondNodeToRemoveParentEdge);
+
+            secondNodeToRemoveParent.addChildEdge(secondEdgeToExtend);
+        }
+
+        if (!networkTerminatesAtMRCA())
+            return Double.NEGATIVE_INFINITY;
+
+        return logHR;
+    }
+
+//    /**
+//     * automatic parameter tuning *
+//     */
+//    @Override
+//    public void optimize(final double logAlpha) {
+//        if (optimiseInput.get()) {
+//            double delta = calcDelta(logAlpha);
+//            delta += Math.log(alpha);
+//            final double f = Math.exp(delta);
+//            if( alpha > 0 ) {
+//                final RecombinationNetwork network = networkInput.get();
+//                final double h = network.getRootEdge().childNode.getHeight();
+//                final double k = Math.log(network.getLeafNodes().size()) / Math.log(2);
+//                final double lim = (h / k) * alpha;
+//                if( f <= lim ) {
+//                	alpha = f;
+//                }
+//            } else {
+//            	alpha = f;
+//            }
+//        }
+//    }
+
+    
+}

--- a/src/coalre/operators/AddRemoveReassortmentCoalescent.java
+++ b/src/coalre/operators/AddRemoveReassortmentCoalescent.java
@@ -53,7 +53,7 @@ public class AddRemoveReassortmentCoalescent extends DivertSegmentOperator {
         logHR -= Math.log(1.0/(double)possibleSourceEdges.size())
                 + Math.log(1.0/sourceEdge.getLength());
         
-        coalescentDistr.intervals.eventListDirty = true;
+//        coalescentDistr.intervals.eventListDirty = true;
         
     	// Calculate tree intervals
     	List<NetworkEvent> networkEventList = coalescentDistr.intervals.getNetworkEventList();
@@ -229,7 +229,7 @@ public class AddRemoveReassortmentCoalescent extends DivertSegmentOperator {
         double destTime = edgeToRemove.parentNode.getHeight();
         
         
-        coalescentDistr.intervals.eventListDirty = true;
+//        coalescentDistr.intervals.eventListDirty = true;
         
     	// Calculate tree intervals
     	List<NetworkEvent> networkEventList = coalescentDistr.intervals.getNetworkEventList();

--- a/src/coalre/operators/EmptyEdgesNetworkOperator.java
+++ b/src/coalre/operators/EmptyEdgesNetworkOperator.java
@@ -78,6 +78,7 @@ public abstract class EmptyEdgesNetworkOperator extends NetworkOperator {
                 network.updateSegmentTree(segmentTrees.get(segIdx), segIdx);
         }        
         
+//        System.out.println(getID());
 //        System.out.println(network);
 //        System.out.println("....");
         

--- a/src/coalre/operators/EmptyEdgesNetworkOperator.java
+++ b/src/coalre/operators/EmptyEdgesNetworkOperator.java
@@ -42,7 +42,10 @@ public abstract class EmptyEdgesNetworkOperator extends NetworkOperator {
        
         double logHR = 0.0;   
         
-        
+//        System.out.println("b");
+//        System.out.println(network);        
+
+
         // Adds empty network edges
         if (addRemoveEmptyEdgesInput.get()){
         	logHR += addEmptyNetworkSegments();
@@ -53,6 +56,8 @@ public abstract class EmptyEdgesNetworkOperator extends NetworkOperator {
          
         // calls the operator
         logHR += networkProposal();
+        
+
 
         // removes all the empty network edges in the network again
         if (addRemoveEmptyEdgesInput.get()){
@@ -72,6 +77,14 @@ public abstract class EmptyEdgesNetworkOperator extends NetworkOperator {
             for (int segIdx=0; segIdx<segmentTrees.size(); segIdx++)
                 network.updateSegmentTree(segmentTrees.get(segIdx), segIdx);
         }        
+        
+//        System.out.println(network);
+//        System.out.println("....");
+        
+//        for (int segIdx=0; segIdx<segmentTrees.size(); segIdx++)
+//            System.out.println(segmentTrees.get(segIdx) +";");
+
+
                 		
         return logHR;
     }

--- a/src/coalre/operators/NetworkOperator.java
+++ b/src/coalre/operators/NetworkOperator.java
@@ -64,6 +64,9 @@ public abstract class NetworkOperator extends Operator {
                 network.updateSegmentTree(segmentTrees.get(segIdx), segIdx);
         }
         
+//        System.out.println(getID());
+//        System.out.println(network);
+        
 //        System.out.println(network);
 //        System.out.println(".............");
 //        

--- a/src/coalre/operators/NetworkOperator.java
+++ b/src/coalre/operators/NetworkOperator.java
@@ -49,6 +49,13 @@ public abstract class NetworkOperator extends Operator {
 //        count += 1;
 //
 //        System.out.println("count = " + count);
+    	
+//        System.out.println(network);
+        
+//        for (int segIdx=0; segIdx<segmentTrees.size(); segIdx++)
+//            System.out.println(segmentTrees.get(segIdx) +";");
+//        System.out.println("=========");
+
 
         double logHR = networkProposal();
 
@@ -56,6 +63,13 @@ public abstract class NetworkOperator extends Operator {
             for (int segIdx=0; segIdx<segmentTrees.size(); segIdx++)
                 network.updateSegmentTree(segmentTrees.get(segIdx), segIdx);
         }
+        
+//        System.out.println(network);
+//        System.out.println(".............");
+//        
+//        for (int segIdx=0; segIdx<segmentTrees.size(); segIdx++)
+//            System.out.println(segmentTrees.get(segIdx) +";");
+
 
         return logHR;
     }


### PR DESCRIPTION
Goes back to remove all the segment naming code as it is unneeded and complicated this. Instead, this just adds the Coalescent Add remove operator